### PR TITLE
chore: manifest.json also needs a bump in version

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -22,7 +22,7 @@ jobs:
         node-version: '20'
 
     - name: Get triggering user's email
-      run: |
+    : |
         user_email=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/users/${{ github.actor }} | jq -r '.email')
         if [ -z "$user_email" ] || [ "$user_email" == "null" ]; then
           user_email="github-actions@github.com"
@@ -34,11 +34,29 @@ jobs:
         git config user.name "${{ github.actor }}"
         git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
 
-
-    - name: Bump version and push tag
+    - name: Bump version, update manifest, commit and tag
       run: |
+        set -euo pipefail
+
         npm install
-        npm version ${{ github.event.inputs.release_type }} -m "chore: bump version to %s"
+
+        # 1) Bump package.json + package-lock.json but DO NOT commit/tag yet
+        npm version ${{ github.event.inputs.release_type }} --no-git-tag-version
+
+        # 2) Read the new version from package.json
+        NEW_VERSION=$(node -p "require('./package.json').version")
+        echo "New version is: $NEW_VERSION"
+
+        # 3) Update manifest.json's "version" field to match
+        jq --arg v "$NEW_VERSION" '.version = $v' manifest.json > manifest.json.tmp
+        mv manifest.json.tmp manifest.json
+
+        # 4) Commit everything and create an annotated tag
+        git add package.json package-lock.json manifest.json
+        git commit -m "chore: bump version to $NEW_VERSION"
+        git tag -a "v$NEW_VERSION" -m "v$NEW_VERSION"
+
+        # 5) Push commit and tag
         git push --follow-tags
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -22,7 +22,7 @@ jobs:
         node-version: '20'
 
     - name: Get triggering user's email
-    : |
+      run: |
         user_email=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/users/${{ github.actor }} | jq -r '.email')
         if [ -z "$user_email" ] || [ "$user_email" == "null" ]; then
           user_email="github-actions@github.com"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "requiredSdkVersion": "~0.0.84",
   "name": "TourPlugin",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "javascriptEntrypointUrl": "TourPlugin.js"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bbb-plugin-tour",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bbb-plugin-tour",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-plugin-tour",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": false,
   "main": "./src/index.tsx",
   "dependencies": {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Rework the github action for cutting a new tag so `manifest.json`'s newly-introduced `version` field also gets bumped up.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
manifest.json 's version was untouched when I was cutting a new tag, leading to confusion.
<!-- What inspired you to submit this pull request? -->


