### PR TITLE
Use caret range for requiredSdkVersion

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.1.14",
+  "requiredSdkVersion": "^0.1.14",
   "name": "TourPlugin",
   "javascriptEntrypointUrl": "TourPlugin.js"
 }


### PR DESCRIPTION
Part of the release tweaks: changes `requiredSdkVersion` in `manifest.json` from a tilde range (`~x.y.z`) to a caret range (`^x.y.z`). Version numbers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)